### PR TITLE
Adds support for Vault Token Helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,8 @@ WantedBy=default.target
 ```
 
 Enable the Vault system unit with `systemctl --user enable vault-agent-dbeaver` and launch the Vault Agent with `systemctl --user start vault-agent-dbeaver`.
+
+
+## Limitations
+
+Support for parsing Vault config file from environment variable `VAULT_CONFIG_PATH` or default `~/.vault` is restricted to [JSON syntax](https://github.com/hashicorp/hcl/blob/main/json/spec.md) only. It does not support [native HCL syntax](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md). 

--- a/plugin/src/com/premiumminds/dbeaver/vault/VaultAuthModelConfigurator.java
+++ b/plugin/src/com/premiumminds/dbeaver/vault/VaultAuthModelConfigurator.java
@@ -75,7 +75,7 @@ public class VaultAuthModelConfigurator implements IObjectPropertyConfigurator<O
 
     @Override
     public boolean isComplete() {
-        return !secretText.getText().isBlank() && !addressText.getText().isBlank();
+        return !secretText.getText().isBlank();
     }
 
 }

--- a/plugin/src/com/premiumminds/dbeaver/vault/VaultConfig.java
+++ b/plugin/src/com/premiumminds/dbeaver/vault/VaultConfig.java
@@ -1,0 +1,8 @@
+package com.premiumminds.dbeaver.vault;
+
+import com.google.gson.annotations.SerializedName;
+
+public class VaultConfig {
+	@SerializedName("token_helper")
+	public String tokenHelper;
+}


### PR DESCRIPTION
Reads from environment variable VAULT_CONFIG_PATH or default ~/.vault and executes the helper directly, with no need for an actual vault executable to be installed.

The Vault config file is a HCL file, wich can be represented by two different syntaxes: native and json.

Supporting native was becoming quite complex.
Adding com.bertramlabs.plugins:hcl4j:0.6.3, following [1], worked up to exporting which failed.

So this only supports Vault config files with JSON syntax.

[1] https://www.vogella.com/tutorials/EclipseJarToPlugin/article.html